### PR TITLE
Add `docker-compose` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+data/seq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# https://medium.com/@gilcrest_65433/containerizing-a-go-api-with-docker-for-mac-7cc2a6b2d3a0
+##################################################################### Builder Stage                                                    # ##################################################################### Start from the golang:alpine image with the latest version of Go installed
+FROM golang:alpine AS builder
+
+# Create WORKDIR using project's root directory
+WORKDIR /go/src/simple-http-go
+
+# Copy the local package files to the container's workspace
+# in the above created WORKDIR
+ADD . .
+
+# Build the api-server inside the container
+RUN go build -o api-server
+
+##################################################################### Final Stage                                                      # ##################################################################### Pull golang alpine image (very small image, with minimum needed to run Go)
+FROM alpine
+
+# Create WORKDIR
+WORKDIR /app
+
+# Copy app binary from the Builder stage image
+COPY --from=builder /go/src/simple-http-go .
+
+# Run the userServer command by default when the container starts.
+ENTRYPOINT ./api-server
+
+# Document that the service uses port 8080
+EXPOSE 8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: '3.7'
+
+services:
+  apiserver:
+    build: .
+    ports:
+      - "5000:8080"
+    depends_on:
+      - seq
+  seq:
+    image: datalust/seq:latest
+    ports:
+      - "5341:80"
+    environment:
+      ACCEPT_EULA: Y
+    restart: unless-stopped
+    volumes:
+      - ./data/seq:/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@ version: '3.7'
 services:
   apiserver:
     build: .
+    environment:
+      SEQ_URL: http://seq:5341
     ports:
       - "5000:8080"
     depends_on:

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	log.AddHook(logruseq.NewSeqHook("http://localhost:5341"))
+	log.AddHook(logruseq.NewSeqHook("http://seq:5341"))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,14 +1,27 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+
 	"github.com/nullseed/logruseq"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
-	"net/http"
 )
 
+// https://stackoverflow.com/a/40326580
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
 func init() {
-	log.AddHook(logruseq.NewSeqHook("http://seq:5341"))
+	seqURL := getEnv("SEQ_URL", "http://localhost:5341")
+	fmt.Printf("Logging to SEQ_URL '%s'\n", seqURL)
+	log.AddHook(logruseq.NewSeqHook(seqURL))
 }
 
 func main() {
@@ -33,5 +46,3 @@ func main() {
 
 	log.Info("Closing down.. bye!")
 }
-
-


### PR DESCRIPTION
This PR adds `docker-compose` support, because it makes the first-run experience nicer.

I realise this is just your experimentation place, and it may not be desirable to add these, so feel free to reject, there are no expectations here  ;) Since I made these anyway as a learning experiment, I figured why not check if you wanted them too?

If this is merged, the following command runs everything, including forcing a rebuild of the `apiserver` itself:

`docker-compose up -d --build apiserver && curl localhost:5000 --verbose && docker-compose down`

The output of a build would be:
```shell
Building apiserver
Step 1/9 : FROM golang:alpine AS builder
 ---> 760fdda71c8f
Step 2/9 : WORKDIR /go/src/simple-http-go
 ---> Using cache
 ---> 38bca099ee37
Step 3/9 : ADD . .
 ---> Using cache
 ---> d92c52c23716
Step 4/9 : RUN go build -o api-server
 ---> Running in 7862f4e85248
go: downloading github.com/sirupsen/logrus v1.5.0
go: downloading github.com/nullseed/logruseq v0.0.0-20191022112445-275e5c09bb04
go: downloading golang.org/x/sys v0.0.0-20190422165155-953cdadca894
Removing intermediate container 7862f4e85248
 ---> 6315a52a8b6d

Step 5/9 : FROM alpine
 ---> a187dde48cd2
Step 6/9 : WORKDIR /app
 ---> Using cache
 ---> 249737fb0576
Step 7/9 : COPY --from=builder /go/src/simple-http-go .
 ---> 1755160f90ce
Step 8/9 : ENTRYPOINT ./api-server
 ---> Running in f944c751186e
Removing intermediate container f944c751186e
 ---> 490a71b4e6ac
Step 9/9 : EXPOSE 8080
 ---> Running in b24070f997ce
Removing intermediate container b24070f997ce
 ---> 3b2b3ab4a3dc

Successfully built 3b2b3ab4a3dc
Successfully tagged simple-http-go_apiserver:latest
Creating simple-http-go_seq_1 ... done
Creating simple-http-go_apiserver_1 ... done
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 5000 (#0)
> GET / HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Mon, 06 Apr 2020 01:14:58 GMT
< Content-Length: 7
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
Hello !* Closing connection 0
Stopping simple-http-go_apiserver_1 ... done
Stopping simple-http-go_seq_1       ... done
Removing simple-http-go_apiserver_1 ... done
Removing simple-http-go_seq_1       ... done
Removing network simple-http-go_default
```
